### PR TITLE
リンクを別タブで表示する＋APIリファレンスの予備リンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # mailsend-handson
 メール送信ハンズオンで使用するコードと関連サイト
 
-- [APIリファレンス](https://sendgrid.com/docs/API_Reference/api_v3.html)
-- [テンプレート機能で利用するサイト](https://www.sendwithus.com/resources/templates)
-- [RequestBin](https://requestbin.aodaruma.com)
+- <a href="https://sendgrid.com/docs/API_Reference/api_v3.html" target="_blank">APIリファレンス</a>
+- <a href="https://www.sendwithus.com/resources/templates" target="_blank">テンプレート機能で利用するサイト</a>
+- <a href="https://requestbin.aodaruma.com" target="_blank">RequestBin</a>
+
+API Referenceの予備
+- [Visual Studio Codeのhttpファイル](https://mchandson.blob.core.windows.net/mchandson/mailsend-handson.http)


### PR DESCRIPTION
・リンクを別タブで表示するためにマークダウンからhrefタグに変更
・APIリファレンスが動作しないケースに備えてVisual Studio CodeのREST Client用httpファイルのリンクを追加